### PR TITLE
refactor: Replace git script with alias

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -12,6 +12,7 @@
 	ca = commit --amend
 	cm = commit-message
 	cms = commit -m 'TODO: squash'
+	commit-message = "!f() { git commit -m \"$(echo $@)\"; }; f"
 	d = diff
 	da = apply
 	dc = diff --cached

--- a/git/bin/git-commit-message
+++ b/git/bin/git-commit-message
@@ -1,4 +1,0 @@
-#!/bin/sh
-sh << EOF
-git commit -m "${@}"
-EOF


### PR DESCRIPTION
to make dependent aliases more portable (eg, sharing with a team).