### PR TITLE
feat: Add git aliases for Conventional Commit types

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -8,11 +8,8 @@
 	bd = branch --delete
 	bm = branch --merged
 	br = branch --move
-	c = commit
-	ca = commit --amend
-	cm = commit-message
+	# Refer to c/commit aliases in ./config.commit
 	cms = commit -m 'TODO: squash'
-	commit-message = "!f() { git commit -m \"$(echo $@)\"; }; f"
 	d = diff
 	da = apply
 	dc = diff --cached
@@ -107,6 +104,7 @@
 
 [include]
 	path = ~/.local/share/git/config
+	path = ~/.config/git/config.commit
 
 [url "git@github.com"]
 	insteadOf = "hub"

--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -9,7 +9,6 @@
 	bm = branch --merged
 	br = branch --move
 	# Refer to c/commit aliases in ./config.commit
-	cms = commit -m 'TODO: squash'
 	d = diff
 	da = apply
 	dc = diff --cached

--- a/git/.config/git/config.commit
+++ b/git/.config/git/config.commit
@@ -1,0 +1,40 @@
+[alias]
+	c = commit
+	# Commit Messages
+	commit-message = "!f() { git commit -m \"$(echo $@)\"; }; f"
+	cm = commit-message
+	cm-build = commit-message build:
+	cm-build-breaking = commit-message 'build!:'
+	cm-chore = commit-message chore:
+	cm-chore-breaking = commit-message 'chore!:'
+	cm-docs = commit-message docs:
+	cm-docs-breaking = commit-message 'docs!:'
+	cm-feat = commit-message feat:
+	cm-feat-breaking = commit-message 'feat!:'
+	cm-fix = commit-message fix:
+	cm-fix-breaking = commit-message 'fix!:'
+	cm-perf = commit-message perf:
+	cm-perf-breaking = commit-message 'perf!:'
+	cm-refactor = commit-message refactor:
+	cm-refactor-breaking = commit-message 'refactor!:'
+	cm-revert = commit-message revert:
+	cm-revert-breaking = commit-message 'revert!:'
+	cm-style = commit-message style:
+	cm-style-breaking = commit-message 'style!:'
+	cm-test = commit-message test:
+	cm-test-breaking = commit-message 'test!:'
+	cm-temp = commit-message temp:
+	cm-temp-breaking = commit-message 'temp!:'
+	# Commit Workflow
+	ca = commit --amend
+	cf = commit-fixup
+	cs = commit-squash
+	rs = rebase-squash
+	rsm = rebase-squash master
+	rsom = rebase-squash origin/master
+	rsum = rebase-squash upstream/master
+	# Commit Helpers
+	commit-fixup = "!f() { if [ $# -eq 0 ]; then git commit --fixup $(git rev-parse HEAD); else git commit --fixup \"$@\"; fi }; f"
+	commit-squash = "!f() { if [ $# -eq 0 ]; then git commit --squash $(git rev-parse HEAD); else git commit --fixup \"$@\"; fi }; f"
+	rebase-squash = rebase --autosquash --interactive
+# vim: filetype=gitconfig


### PR DESCRIPTION
To make it easier to type and easier to remember:
- `gcm-<Tab>`
- `git cm-<Tab>`