### PR TITLE
fix(bootstrap): force `apt-get update` when installing packages

### DIFF
--- a/.requirements/apt.mk
+++ b/.requirements/apt.mk
@@ -21,8 +21,8 @@ endif
 
 .PHONY: system.apt
 system.apt:  ## Install apt packages
-ifeq ($(APT_UPDATE),1)
 	$(SUDO) apt-get update --yes
+ifeq ($(APT_UPDATE),1)
 	$(SUDO) apt-get upgrade --yes
 	$(SUDO) apt-get dist-upgrade --yes
 endif


### PR DESCRIPTION
This is not only best practice, but also resolves an issue with
persistent 404s on Github Actions workflows.