### PR TITLE
feat(i3)!: drop hotkey support for arrow navigation

### DIFF
--- a/window-manager/.config/i3/config
+++ b/window-manager/.config/i3/config
@@ -87,23 +87,12 @@ bindsym $mod+j focus down
 bindsym $mod+k focus up
 bindsym $mod+l focus right
 
-# alternatively, you can use the cursor keys:
-bindsym $mod+Left focus left
-bindsym $mod+Down focus down
-bindsym $mod+Up focus up
-bindsym $mod+Right focus right
-
 # move focused window
 bindsym $mod+Shift+h move left
 bindsym $mod+Shift+j move down
 bindsym $mod+Shift+k move up
 bindsym $mod+Shift+l move right
 
-# alternatively, you can use the cursor keys:
-bindsym $mod+Shift+Left move left
-bindsym $mod+Shift+Down move down
-bindsym $mod+Shift+Up move up
-bindsym $mod+Shift+Right move right
 
 # split in horizontal orientation
 bindsym $mod+| split h


### PR DESCRIPTION
and instead rely solely on VI-style HJKL-key navigation.

Not only was I not really using these, but they conflict with Firefox/browser page navigation (if $mod == Mod1);
- ALT-LEFT: page back
- ALT-RIGHT: page forward