### PR TITLE
fix(i3): make $mod+Shift+Tab actually go back to the previous workspace

### DIFF
--- a/window-manager/.config/i3/config
+++ b/window-manager/.config/i3/config
@@ -49,7 +49,7 @@ assign [class="Firefox"] 2
 assign [class="Chrome"] 3
 
 bindsym $mod+Tab workspace next
-bindsym $mod+Shift+Tab workspace next
+bindsym $mod+Shift+Tab workspace prev
 workspace_auto_back_and_forth yes
 
 # Use pactl to adjust volume in PulseAudio.


### PR DESCRIPTION
It was mistakenly just cycling forward;
this was probably a copy/paste fail when adapting from $mod+Tab.