### PR TITLE
fix(screen): set default screen shell with relative pathname

### DIFF
--- a/screen/.config/screen/rc
+++ b/screen/.config/screen/rc
@@ -41,4 +41,4 @@ term screen-256color
 # term xterm-256color
 #   When using rxvt-unicode:
 # term rxvt-unicode-256color
-shell '/bin/zsh'
+shell zsh


### PR DESCRIPTION
in case we're running a newer version installed to ${HOME} (or /nix), etc.